### PR TITLE
chore(go): update to Go v1.22.5 EE-7297

### DIFF
--- a/.github/workflows/dev.workflow.yaml
+++ b/.github/workflows/dev.workflow.yaml
@@ -28,7 +28,7 @@ jobs:
           driver-opts: image=moby/buildkit:v0.10.6
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.21.9"
+          go-version: "1.22.5"
       - name: login to docker hub
         run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
 

--- a/.github/workflows/prod.workflow.yaml
+++ b/.github/workflows/prod.workflow.yaml
@@ -23,7 +23,7 @@ jobs:
           driver-opts: image=moby/buildkit:v0.10.6
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.21.9"
+          go-version: "1.22.5"
       - name: login to docker hub
         run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/portainer/portainer-updater
 
-go 1.21
+go 1.22
 
-toolchain go1.21.9
+toolchain go1.22.5
 
 require (
 	github.com/Masterminds/semver v1.5.0


### PR DESCRIPTION
[EE-7297]

[EE-7297]: https://portainer.atlassian.net/browse/EE-7297?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Ref BE-2296