### PR TITLE
2024-09-CVE

### DIFF
--- a/build/windows/Dockerfile
+++ b/build/windows/Dockerfile
@@ -2,7 +2,7 @@ ARG GIT_COMMIT=unspecified
 ARG OSVERSION
 FROM --platform=linux/amd64 gcr.io/k8s-staging-e2e-test-images/windows-servercore-cache:1.0-linux-amd64-${OSVERSION} as core
 FROM --platform=linux/amd64 alpine:3.13.0 as downloader
-ENV GIT_VERSION 2.44.0
+ENV GIT_VERSION 2.45.2
 ENV GIT_PATCH_VERSION 1
 
 RUN mkdir mingit/ \

--- a/build/windows/Dockerfile
+++ b/build/windows/Dockerfile
@@ -2,7 +2,7 @@ ARG GIT_COMMIT=unspecified
 ARG OSVERSION
 FROM --platform=linux/amd64 gcr.io/k8s-staging-e2e-test-images/windows-servercore-cache:1.0-linux-amd64-${OSVERSION} as core
 FROM --platform=linux/amd64 alpine:3.13.0 as downloader
-ENV GIT_VERSION 2.45.2
+ENV GIT_VERSION 2.46.0
 ENV GIT_PATCH_VERSION 1
 
 RUN mkdir mingit/ \

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.6
 require (
 	github.com/Masterminds/semver v1.5.0
 	github.com/alecthomas/kong v0.5.0
-	github.com/docker/docker v26.0.1+incompatible
+	github.com/docker/docker v26.1.5+incompatible
 	github.com/hashicorp/nomad/api v0.0.0-20221020074335-1c9b4e398dd2
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.28.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/portainer/portainer-updater
 
-go 1.22.6
+go 1.22.7
 
 require (
 	github.com/Masterminds/semver v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -24,8 +24,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
-github.com/docker/docker v26.0.1+incompatible h1:t39Hm6lpXuXtgkF0dm1t9a5HkbUfdGy6XbWexmGr+hA=
-github.com/docker/docker v26.0.1+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v26.1.5+incompatible h1:NEAxTwEjxV6VbBMBoGG3zPqbiJosIApZjxlbrG9q3/g=
+github.com/docker/docker v26.1.5+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
 github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=


### PR DESCRIPTION
cli tool update - mingit 2.46.0 (CVE-2021-24112) (CVE-2024-30105)
go.mod - github.com/docker/docker v26.1.5+incompatible (CVE-2024-41110)